### PR TITLE
Login page XPath updates; auto-login again functional

### DIFF
--- a/src/main/resources/SiteDetails.properties
+++ b/src/main/resources/SiteDetails.properties
@@ -4,9 +4,9 @@ bookName=managerial-accounting-for-managers-3d
 
 ##Login Page Details:
 loginPage=https://www.chegg.com/login/
-usernameXpath=//*[@id="eggshell-16"]/form/input[1]
-passwordXpath=//*[@id="eggshell-16"]/form/input[2]
-submitXpath=//*[@id="eggshell-16"]/form/input[3]
+usernameXpath=//*[@id="eggshell-18"]/form/input[1]
+passwordXpath=//*[@id="eggshell-18"]/form/input[2]
+submitXpath=//*[@id="eggshell-18"]/form/input[3]
 
 
 ##User login details


### PR DESCRIPTION
Due to them being outdated, and subsequently preventing the auto-login script from working, I updated the XPath login field IDs to match the current—as of 27 Mar. 2015—login page. Auto-login should now be fine.
